### PR TITLE
Updated author_summary length to accommodate longer passages

### DIFF
--- a/app/models/books.py
+++ b/app/models/books.py
@@ -13,7 +13,7 @@ class Books(db.Model):
     release_date: Mapped[datetime.date] = mapped_column(Date)
     previous: Mapped[str] = mapped_column(String(255))
     next: Mapped[str] = mapped_column(String(255))
-    author_summary: Mapped[str] = mapped_column(String(255))
+    author_summary: Mapped[str] = mapped_column(String(2048))
     image: Mapped[str] = mapped_column(String(255))
     author: Mapped[str] = mapped_column(String(255))
     narrator: Mapped[str] = mapped_column(String(255))

--- a/tasks/scraper_tasks.py
+++ b/tasks/scraper_tasks.py
@@ -9,8 +9,8 @@ def run_all_scrapers():
     try:
         # species_scraper()
         # ship_scraper()
-        planet_scraper()
-        # book_scraper()
+        # planet_scraper()
+        book_scraper()
         # character_scraper()
     except Exception as e:
         print(f"Error: {e}")


### PR DESCRIPTION
When trying to add to DB, an error was being thrown due to the length of the author summary in comparison to the size of the field. Increased the field size to 2048 to be able to hold the full passage.