### PR TITLE
Adding Caching & Memoization on backend

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from .routes import init_routes
+from .routes import init_routes, cache
 from .models import db
 from flask_cors import CORS
 
@@ -7,7 +7,8 @@ def create_app():
     app = Flask(__name__)
     CORS(app)
     app.config.from_object("config.Config")
-
+    
+    cache.init_app(app)
     db.init_app(app)
     init_routes(app)
 

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,3 +1,6 @@
+from flask_caching import Cache
+cache = Cache()
+
 from .ships import ships_bp
 from .books import books_bp
 from .character import characters_bp

--- a/app/routes/books.py
+++ b/app/routes/books.py
@@ -2,10 +2,13 @@ from flask import Blueprint
 from sqlalchemy import select
 from app.models import db
 from app.models.books import Books, books_schema, book_schema
+from app.routes import cache
+
 
 books_bp = Blueprint("books", __name__)
 
 @books_bp.route("/books", methods=['GET'])
+@cache.cached(timeout=60)
 def get_books():
     rows = select(Books)
 
@@ -14,6 +17,7 @@ def get_books():
     return books_schema.dump(books)
 
 @books_bp.route("/books/<int:id>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_book_by_id(id):
     row = select(Books).where(Books.id == id)
     result = db.session.execute(row).scalar_one_or_none()
@@ -21,6 +25,7 @@ def get_book_by_id(id):
     return book_schema.dump(book)
 
 @books_bp.route("/books/<string:name>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_book_by_name(name):
     row = select(Books).where(Books.name == name)
     result = db.session.execute(row).scalar_one_or_none()

--- a/app/routes/character.py
+++ b/app/routes/character.py
@@ -2,10 +2,11 @@ from flask import Blueprint
 from sqlalchemy import select
 from app.models import db
 from app.models.characters import Characters, characters_schema, character_schema
-
+from app.routes import cache
 characters_bp = Blueprint("characters", __name__)
 
 @characters_bp.route("/characters", methods=['GET'])
+@cache.cached(timeout=60)
 def get_characters():
     rows = select(Characters)
 
@@ -14,6 +15,7 @@ def get_characters():
     return characters_schema.dump(characters)
 
 @characters_bp.route("/characters/<int:id>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_id(id):
     row = select(Characters).where(Characters.id == id)
     result = db.session.execute(row).scalar_one_or_none()
@@ -21,6 +23,7 @@ def get_character_by_id(id):
     return character_schema.dump(character)
 
 @characters_bp.route("/characters/<string:name>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_name(name):
     row = select(Characters).where(Characters.name == name)
     result = db.session.execute(row).scalar_one_or_none()

--- a/app/routes/planet.py
+++ b/app/routes/planet.py
@@ -2,10 +2,11 @@ from flask import Blueprint
 from sqlalchemy import select
 from app.models import db
 from app.models.planets import Planets, planets_schema, planet_schema
-
+from app.routes import cache
 planets_bp = Blueprint("planets", __name__)
 
 @planets_bp.route("/planets", methods=['GET'])
+@cache.cached(timeout=60)
 def get_planets():
     rows = select(Planets)
 
@@ -14,6 +15,7 @@ def get_planets():
     return planets_schema.dump(planets)
 
 @planets_bp.route("/planets/<int:id>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_id(id):
     row = select(Planets).where(Planets.id == id)
     result = db.session.execute(row).scalar_one_or_none()
@@ -21,6 +23,7 @@ def get_character_by_id(id):
     return planet_schema.dump(result)
 
 @planets_bp.route("/planets/<string:name>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_name(name):
     row = select(Planets).where(Planets.name == name)
     result = db.session.execute(row).scalar_one_or_none()

--- a/app/routes/ships.py
+++ b/app/routes/ships.py
@@ -2,10 +2,11 @@ from flask import Blueprint
 from sqlalchemy import select
 from app.models import db
 from app.models.ships import Ships, ships_schema, ship_schema
-
+from app.routes import cache
 ships_bp = Blueprint("ships", __name__)
 
 @ships_bp.route("/ships", methods=['GET'])
+@cache.cached(timeout=60)
 def get_ships():
     rows = select(Ships)
 
@@ -14,6 +15,7 @@ def get_ships():
     return ships_schema.dump(ships)
 
 @ships_bp.route("/ships/<int:id>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_id(id):
     row = select(Ships).where(Ships.id == id)
     result = db.session.execute(row).scalar_one_or_none()
@@ -21,6 +23,7 @@ def get_character_by_id(id):
     return ship_schema.dump(result)
 
 @ships_bp.route("/ships/<string:name>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_name(name):
     row = select(Ships).where(Ships.name == name)
     result = db.session.execute(row).scalar_one_or_none()

--- a/app/routes/species.py
+++ b/app/routes/species.py
@@ -2,10 +2,11 @@ from flask import Blueprint
 from sqlalchemy import select
 from app.models import db
 from app.models.species import Species, speciess_schema, species_schema
-
+from app.routes import cache
 species_bp = Blueprint("species", __name__)
 
 @species_bp.route("/species", methods=['GET'])
+@cache.cached(timeout=60)
 def get_species():
     rows = select(Species)
 
@@ -14,6 +15,7 @@ def get_species():
     return speciess_schema.dump(species)
 
 @species_bp.route("/species/<int:id>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_id(id):
     row = select(Species).where(Species.id == id)
     result = db.session.execute(row).scalar_one_or_none()
@@ -21,6 +23,7 @@ def get_character_by_id(id):
     return species_schema.dump(result)
 
 @species_bp.route("/species/<string:name>", methods=['GET'])
+@cache.memoize(timeout=60)
 def get_character_by_name(name):
     row = select(Species).where(Species.name == name)
     result = db.session.execute(row).scalar_one_or_none()

--- a/config.py
+++ b/config.py
@@ -1,9 +1,12 @@
 from dotenv import load_dotenv
 import os
 
+
 # load_dotenv()
 
 class Config:
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URI')
     SQLALCHEMY_TRACK_NOTIFICATIONS = False
     SECRET_KEY = os.getenv('SECRET_KEY')
+    CACHE_TYPE = 'SimpleCache'
+    CACHE_DEFAULT_TIMEOUT = 300

--- a/run.py
+++ b/run.py
@@ -5,9 +5,7 @@ from app.models import db
 
 
 load_dotenv()
-
 app = create_app()
-
 
 if __name__ == "__main__":
     with app.app_context():


### PR DESCRIPTION
Added caching for all "get all" routes, including ships, species, planets, characters, and books with an initial timeout of 60 seconds. Added memoization for routes that had an id or name that could change, provided in the request.